### PR TITLE
fix(plugin-meetings): prevent LLM connection from being permanently killed

### DIFF
--- a/packages/@webex/plugin-meetings/src/meeting/index.ts
+++ b/packages/@webex/plugin-meetings/src/meeting/index.ts
@@ -6321,6 +6321,9 @@ export default class Meeting extends StatelessWebexPlugin {
         code: 3050,
         reason: 'done (permanent)',
       });
+      LoggerProxy.logger.info(
+        'Meeting:index#cleanupLLMConneciton --> disconnect default LLM session'
+      );
     } catch (error) {
       LoggerProxy.logger.error(
         'Meeting:index#cleanupLLMConneciton --> Failed to disconnect default LLM session',
@@ -6453,10 +6456,28 @@ export default class Meeting extends StatelessWebexPlugin {
       ) {
         return undefined;
       }
+
+      // Don't disconnect the shared LLM connection if we cannot reconnect.
+      // This prevents permanently killing the LLM when:
+      // 1. An unjoined meeting (e.g. incoming CALL) triggers updateLLMConnection
+      // 2. datachannelUrl becomes null/undefined due to a locus.difference event
+      if (!isJoined || !url || !dataChannelUrl) {
+        LoggerProxy.logger.info(
+          'Meeting:index#updateLLMConnection --> Not disconnecting LLM: reconnection not feasible' +
+            ` (isJoined=${isJoined}, hasUrl=${!!url}, hasDataChannelUrl=${!!dataChannelUrl})`
+        );
+
+        return undefined;
+      }
+
       await this.cleanupLLMConneciton({removeOnlineListener: false});
     }
 
     if (!isJoined) {
+      LoggerProxy.logger.info(
+        'Meeting:index#updateLLMConnection --> No need reconnect default llm'
+      );
+
       return undefined;
     }
 

--- a/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
+++ b/packages/@webex/plugin-meetings/test/unit/spec/meeting/index.js
@@ -2354,20 +2354,22 @@ describe('plugin-meetings', () => {
 
               meeting.updateLLMConnection.restore();
 
+              // First connect with isJoined=true, LLM not connected
               isJoinedStub.returns(true);
               meeting.webex.internal.llm.isConnected.returns(false);
               await meeting.updateLLMConnection();
 
               assert.exists(meeting.llmHealthCheckTimer);
 
-              isJoinedStub.returns(false);
+              // Now disconnect: LLM is connected, URLs differ, isJoined=true
+              // so it should disconnect and try to reconnect (but isJoined is true and URLs are valid)
+              isJoinedStub.returns(true);
               meeting.webex.internal.llm.isConnected.returns(true);
+              meeting.locusInfo = {url: 'https://locus2.example.com', info: {datachannelUrl: 'https://datachannel2.example.com'}};
 
               await meeting.updateLLMConnection();
 
               assert.calledOnce(meeting.webex.internal.llm.disconnectLLM);
-
-              assert.isUndefined(meeting.llmHealthCheckTimer);
 
               Metrics.sendBehavioralMetric.resetHistory();
               fakeClock.tick(3 * 60 * 1000);
@@ -2376,6 +2378,64 @@ describe('plugin-meetings', () => {
                 Metrics.sendBehavioralMetric,
                 BEHAVIORAL_METRICS.LLM_HEALTHCHECK_FAILURE
               );
+            });
+
+            it('does not disconnect LLM when isJoined is false (unjoined meeting)', async () => {
+              sinon.stub(meeting, 'isJoined').returns(false);
+              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(true);
+              sinon.stub(meeting.webex.internal.llm, 'disconnectLLM').resolves();
+              sinon
+                .stub(meeting.webex.internal.llm, 'getLocusUrl')
+                .returns('https://locus1.example.com');
+              sinon
+                .stub(meeting.webex.internal.llm, 'getDatachannelUrl')
+                .returns('https://datachannel1.example.com');
+
+              meeting.updateLLMConnection.restore();
+              meeting.locusInfo = {url: 'https://different-locus.example.com', info: {datachannelUrl: 'https://datachannel.example.com'}};
+
+              await meeting.updateLLMConnection();
+
+              assert.notCalled(meeting.webex.internal.llm.disconnectLLM);
+            });
+
+            it('does not disconnect LLM when datachannelUrl becomes null', async () => {
+              sinon.stub(meeting, 'isJoined').returns(true);
+              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(true);
+              sinon.stub(meeting.webex.internal.llm, 'disconnectLLM').resolves();
+              sinon
+                .stub(meeting.webex.internal.llm, 'getLocusUrl')
+                .returns('https://locus1.example.com');
+              sinon
+                .stub(meeting.webex.internal.llm, 'getDatachannelUrl')
+                .returns('https://datachannel1.example.com');
+
+              meeting.updateLLMConnection.restore();
+              // datachannelUrl cleared by locus.difference
+              meeting.locusInfo = {url: 'https://locus1.example.com', info: {datachannelUrl: undefined}};
+
+              await meeting.updateLLMConnection();
+
+              assert.notCalled(meeting.webex.internal.llm.disconnectLLM);
+            });
+
+            it('does not disconnect LLM when locusUrl is missing', async () => {
+              sinon.stub(meeting, 'isJoined').returns(true);
+              sinon.stub(meeting.webex.internal.llm, 'isConnected').returns(true);
+              sinon.stub(meeting.webex.internal.llm, 'disconnectLLM').resolves();
+              sinon
+                .stub(meeting.webex.internal.llm, 'getLocusUrl')
+                .returns('https://locus1.example.com');
+              sinon
+                .stub(meeting.webex.internal.llm, 'getDatachannelUrl')
+                .returns('https://datachannel1.example.com');
+
+              meeting.updateLLMConnection.restore();
+              meeting.locusInfo = {url: undefined, info: {datachannelUrl: 'https://datachannel1.example.com'}};
+
+              await meeting.updateLLMConnection();
+
+              assert.notCalled(meeting.webex.internal.llm.disconnectLLM);
             });
           });
 


### PR DESCRIPTION
## Problem

`updateLLMConnection()` disconnects the shared LLM singleton (code 3050, permanent) **before** validating whether reconnection is feasible. This causes permanent LLM loss in two scenarios:

1. **Unjoined meeting triggers disconnect** - An incoming CALL creates a new meeting object that calls `updateLLMConnection()`. Since `isJoined()` is false on the new meeting, it disconnects the webinar LLM but never reconnects.

2. **datachannelUrl cleared by locus.difference** - A locus delta clears `datachannelUrl`. The method disconnects the LLM, then `registerAndConnect()` silently bails out because `datachannelUrl` is null.

## Fix

Add a guard before `cleanupLLMConneciton()` that validates reconnection is feasible (`isJoined`, `url`, and `dataChannelUrl` must all be truthy). If reconnection is not possible, the existing LLM connection is preserved.

## Testing

- Updated existing test for the new behavior
- Added 3 new unit tests covering both failure scenarios
- All 3273 unit tests pass

